### PR TITLE
CachedMixin should only concern itself with cache functionality.

### DIFF
--- a/agiliqcom/agiliqpages/views.py
+++ b/agiliqcom/agiliqpages/views.py
@@ -35,24 +35,28 @@ def error_page(request):
 
 
 class CachedMixin(object):
-    extra_context = None
 
     @classonlymethod
     def as_view(cls, **initkwargs):
         return cache_page(super(CachedMixin, cls).as_view(**initkwargs), settings.CACHE_DURATION)
 
+
+class CachedTemplateView(CachedMixin, TemplateView):
+    extra_context = None
+
     def get_context_data(self, **kwargs):
-        context = super(CachedMixin, self).get_context_data(**kwargs)
+        context = super(CachedTemplateView, self).get_context_data(**kwargs)
         context.update(self.extra_context)
         return context
 
 
-class CachedTemplateView(CachedMixin, TemplateView):
-    pass
-
-
 class CachedListView(CachedMixin, ListView):
-    pass
+    extra_context = None
+
+    def get_context_data(self, **kwargs):
+        context = super(CachedListView, self).get_context_data(**kwargs)
+        context.update(self.extra_context)
+        return context
 
 
 # @cache_page(settings.CACHE_DURATION)


### PR DESCRIPTION
@tuxcanfly Removed extra_context handling functionality from CachedMixin. 
Now there is some duplication because both CachedTemplateView and CachedListView need to handle extra_context. It can be handled by creating another mixin ExtraContextMixin that handles extra_context. And CachedTemplateView and CachedListView can extend from ExtraContextMixin.
